### PR TITLE
fix com.tns.NativeScriptApplication.getInstance on android

### DIFF
--- a/src/mixpanel.android.ts
+++ b/src/mixpanel.android.ts
@@ -1,5 +1,5 @@
 import { Common } from './mixpanel.common';
-
+import * as app from 'tns-core-modules/application';
 declare var com;
 
 let mixpanel;
@@ -11,7 +11,7 @@ export class MixpanelHelper extends Common {
     }
 
     static init(token) {
-        let context = com.tns.NativeScriptApplication.getInstance();
+        const context = app.android.context
         if (token) {
             if (com.mixpanel && context) {
                 mixpanel = com.mixpanel.android.mpmetrics.MixpanelAPI.getInstance(context, token + "");


### PR DESCRIPTION
Builds but fails on run for android devices; with NS 6.2.x 


`      var context = com.tns.NativeScriptApplication.getInstance();`

was deprecated by Nativescript, this is causing build failures on 6.2.2

replaced with 
`        const context = app.android.context
`